### PR TITLE
Python compatibility checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ OctoText will notify you via text (or email) on common printer events. The curre
    <li> File uploaded</li>
    <li> Print started</li>
    <li> Print done</li>
-   <li> Timelapse done</li>
    <li> Print failure </li>
    <li> Peroidic progress updates </li>
    <li> Error (unrecoverable)</li>

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ plugin_ignored_packages = []
 # Example:
 #     plugin_requires = ["someDependency==dev"]
 #     additional_setup_parameters = {"dependency_links": ["https://github.com/someUser/someRepo/archive/master.zip#egg=someDependency-dev"]}
-additional_setup_parameters = {}
+additional_setup_parameters = {"python_requires": ">=3, <4"}
 
 ########################################################################################################################
 


### PR DESCRIPTION
The install should not allow the plugin to be installed on a Python 2 Octoprint - it just won't install correctly because of the packages required. The changes to setup prohibit this.

Also removed the comment on timelapse notifications, as this is not implemented.