### PR TITLE
Fix for rotated or flipped webcam snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ or manually using this URL:
 
     https://github.com/berrystephenw/OctoText/archive/refs/heads/main.zip
 
-The plugin needs no special installation.
+The plugin <b><i>requires a Python 3 installation in OctoPrint. </i></b>
+If you have an older OctoPrint install and would like to upgrade (after checking to be sure your other plugins are Python 3 compatible) then you can do that by folling the instructions here: https://community.octoprint.org/t/upgrade-your-octoprint-install-to-python-3/23973
 
 ## Configuration
 

--- a/octoprint_OctoText/__init__.py
+++ b/octoprint_OctoText/__init__.py
@@ -89,8 +89,6 @@ class OctoTextPlugin(octoprint.plugin.EventHandlerPlugin,
 		# core UI here.
 		return dict(
 			js=["js/OctoText.js"]
-#			css=["css/OctoText.css"],
-#			less=["less/OctoText.less"]
 		)
 
 	def get_template_configs(self):
@@ -259,6 +257,11 @@ class OctoTextPlugin(octoprint.plugin.EventHandlerPlugin,
 			if not (error == None):
 				return error
 
+			if body == None:
+				body = self._settings.global_get(["appearance", "name"])
+			
+			self._logger.info("Appearance name (subject): {}".format(self._settings.global_get(["appearance", "name"])))
+
 			login = self._settings.get(["server_login"])
 			msg = EmailMessage()
 			msg['Subject'] = body
@@ -292,7 +295,7 @@ class OctoTextPlugin(octoprint.plugin.EventHandlerPlugin,
 				return "SENDM_E"
 			return True
 
-	# this is currently not called but should be tested on a Pi (was disabled for debug)
+	# this code will rotate or flip the image based on the webcam settings. borrowed from foosel
 	def _process_snapshot(self, snapshot_path, pixfmt="yuv420p"):
 			hflip  = self._settings.global_get_boolean(["webcam", "flipH"])
 			vflip  = self._settings.global_get_boolean(["webcam", "flipV"])
@@ -313,7 +316,7 @@ class OctoTextPlugin(octoprint.plugin.EventHandlerPlugin,
 				rotate_params.append("vflip")		# vertical flip
 
 			ffmpeg_command += ["-vf", sarge.shell_quote(",".join(rotate_params)), snapshot_path]
-			self._logger.info("Running: {}".format(" ".join(ffmpeg_command)))
+			#self._logger.info("Running: {}".format(" ".join(ffmpeg_command)))
 			try:
 				p = sarge.run(ffmpeg_command)
 			except Exception as e:

--- a/octoprint_OctoText/__init__.py
+++ b/octoprint_OctoText/__init__.py
@@ -238,7 +238,7 @@ class OctoTextPlugin(octoprint.plugin.EventHandlerPlugin,
 				tempFile.name += ".jpg"
 
 				self._logger.info("Webcam tempfile {}".format(tempFile.name))
-				self._process_snapshot(tempFile)
+				self._process_snapshot(tempFile.name)
 				result = self._send_file(sender, tempFile.name, filename, title + " " + body)
 				if result == True:
 					try:
@@ -313,8 +313,7 @@ class OctoTextPlugin(octoprint.plugin.EventHandlerPlugin,
 				rotate_params.append("vflip")		# vertical flip
 
 			ffmpeg_command += ["-vf", sarge.shell_quote(",".join(rotate_params)), snapshot_path]
-			#self._logger.info("Running: {}".format(" ".join(ffmpeg_command)))
-			# bug on next line: TypeError: sequence item 3: expected str instance, _TemporaryFileWrapper found
+			self._logger.info("Running: {}".format(" ".join(ffmpeg_command)))
 			try:
 				p = sarge.run(ffmpeg_command)
 			except Exception as e:

--- a/octoprint_OctoText/__init__.py
+++ b/octoprint_OctoText/__init__.py
@@ -313,7 +313,7 @@ class OctoTextPlugin(octoprint.plugin.EventHandlerPlugin,
 				rotate_params.append("vflip")		# vertical flip
 
 			ffmpeg_command += ["-vf", sarge.shell_quote(",".join(rotate_params)), snapshot_path]
-			self._logger.info("Running: {}".format(" ".join(ffmpeg_command)))
+			#self._logger.info("Running: {}".format(" ".join(ffmpeg_command)))
 
 			p = sarge.run(ffmpeg_command, stdout=sarge.Capture(), stderr=sarge.Capture())
 			if p.returncode == 0:

--- a/octoprint_OctoText/__init__.py
+++ b/octoprint_OctoText/__init__.py
@@ -317,7 +317,7 @@ class OctoTextPlugin(octoprint.plugin.EventHandlerPlugin,
 			# bug on next line: TypeError: sequence item 3: expected str instance, _TemporaryFileWrapper found
 			try:
 				p = sarge.run(ffmpeg_command)
-			except Exception e:
+			except Exception as e:
 				self._logger.info("Exception running ffmpeg {}".format(e))
 				return
 

--- a/octoprint_OctoText/__init__.py
+++ b/octoprint_OctoText/__init__.py
@@ -314,8 +314,13 @@ class OctoTextPlugin(octoprint.plugin.EventHandlerPlugin,
 
 			ffmpeg_command += ["-vf", sarge.shell_quote(",".join(rotate_params)), snapshot_path]
 			#self._logger.info("Running: {}".format(" ".join(ffmpeg_command)))
+			# bug on next line: TypeError: sequence item 3: expected str instance, _TemporaryFileWrapper found
+			try:
+				p = sarge.run(ffmpeg_command)
+			except Exception e:
+				self._logger.info("Exception running ffmpeg {}".format(e))
+				return
 
-			p = sarge.run(ffmpeg_command, stdout=sarge.Capture(), stderr=sarge.Capture())
 			if p.returncode == 0:
 				self._logger.info("Rotated/flipped image with ffmpeg")
 			else:


### PR DESCRIPTION
If the webcam was rotated or flipped, the code that was run to adjust the image had a bad pointer to the image.  An additional change was made for texts that were sent without a subject line - the printer name was inserted in those cases. 