### PR TITLE
Skip smtp authentication if password field is blank

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include README.md
 recursive-include octoprint_OctoText/templates *
 recursive-include octoprint_OctoText/translations *
 recursive-include octoprint_OctoText/static *
-include octoprint_fortune/fortunes
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include README.md
 recursive-include octoprint_OctoText/templates *
 recursive-include octoprint_OctoText/translations *
 recursive-include octoprint_OctoText/static *
+include octoprint_fortune/fortunes

--- a/README.md
+++ b/README.md
@@ -15,18 +15,22 @@ OctoText will notify you via text (or email) on common printer events. The curre
 
 OctoText will also include a thumbnail of your print if <b> you have loaded [PrusaSlicer Thumbnails](https://github.com/jneilliii/OctoPrint-PrusaSlicerThumbnails)
 or [Cura Thumbnails](https://github.com/jneilliii/OctoPrint-UltimakerFormatPackage) plugins</b>.
-This is a change from previous OctoText revisions where OctoText was handling the thumbnails directly. Essentially
-loading these plugins allows for a better interface with Cura and less redundancy for those that already use the
-Prusa and Cura plugins. Just search for 'thumbnail' in the plugin manager.
+**This is a change from previous OctoText revisions where OctoText was handling the thumbnails directly.** 
+Loading these plugins allows for a better interface with Cura and less redundancy for those that already use the
+Prusa and Cura plugins. Just search for 'thumbnail' in the plugin manager to find them.
+
+The thumbnail will only be sent on a print START event.
 
 This release also introduces retries for network outages, where messages will retry for up to 5 minutes. An API is introduced
 so other plugins can send custom messages through OctoText. An example plugin that shows how this works can be found 
 here: [TextAPI](https://github.com/berrystephenw/OctoPrint-Textapi).
 
-The thumbnail will only be sent on a print START event.
-
-Print Pausing detection has been enhanced so that it detects "waiting for user messages" that are sent by Prusa printers
+Print Pausing detects "waiting for user messages" that are sent by Prusa printers
 on filament run out conditions.
+
+A bug was fixed when webcams that are enabled in OctoText, but the cam isn't working (for whatever reason) OctoText didn't send
+any notifications. This has been changed so the text portion of the message is still sent along with
+a friendly image telling you your webcam is down.
 
 <img width="128" alt="OctoText" src="assets/img/iconfinder_13_1236350.png">
 <p>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ here: [TextAPI](https://github.com/berrystephenw/OctoPrint-Textapi).
 Print Pausing detects "waiting for user messages" that are sent by Prusa printers
 on filament run out conditions.
 
-A bug was fixed when webcams that are enabled in OctoText, but the cam isn't working (for whatever reason) OctoText didn't send
+A bug was fixed when webcams are enabled in OctoText, but the cam isn't working (for whatever reason) OctoText didn't send
 any notifications. This has been changed so the text portion of the message is still sent along with
 a friendly image telling you your webcam is down.
 

--- a/octoprint_OctoText/__init__.py
+++ b/octoprint_OctoText/__init__.py
@@ -245,16 +245,21 @@ class OctoTextPlugin(
 
         # login to the mail account
         self._logger.debug(login)
-        try:
-            SMTP_server.login(login, passw)
-        except Exception as e:
-            self._logger.exception(
-                "Exception while logging into mail server {message}".format(
-                    message=str(e)
+        self._logger.info('logging in bro2')
+        if passw:
+            self._logger.debug('password supplied, attempting to log into mail server')
+            try:
+                SMTP_server.login(login, passw)
+            except Exception as e:
+                self._logger.exception(
+                    "Exception while logging into mail server {message}".format(
+                        message=str(e)
+                    )
                 )
-            )
-            SMTP_server.quit()
-            return ["LOGIN_E", None]
+                SMTP_server.quit()
+                return ["LOGIN_E", None]
+        else:
+            self._logger.debug('Password not supplied, proceeding without SMTP authentication.')
 
         email_addr = phone_numb + "@%s" % carrier_addr
         return [None, email_addr]

--- a/octoprint_OctoText/__init__.py
+++ b/octoprint_OctoText/__init__.py
@@ -245,9 +245,8 @@ class OctoTextPlugin(
 
         # login to the mail account
         self._logger.debug(login)
-        self._logger.info('logging in bro2')
         if passw:
-            self._logger.debug('password supplied, attempting to log into mail server')
+            self._logger.debug('Password supplied, attempting to log into mail server')
             try:
                 SMTP_server.login(login, passw)
             except Exception as e:

--- a/octoprint_OctoText/static/js/OctoText.js
+++ b/octoprint_OctoText/static/js/OctoText.js
@@ -4,6 +4,13 @@
  * Author: Stephen Berry
  * License: AGPLv3
  */
+
+$(document).ready(function(){
+    $('[tool-tip-toggle="tooltip"]').tooltip({
+        placement : 'bottom'
+    });
+});
+
 $(function() {
     function OctoTextViewModel(parameters) {
         var self = this;

--- a/octoprint_OctoText/templates/OctoText_navbar.jinja2
+++ b/octoprint_OctoText/templates/OctoText_navbar.jinja2
@@ -1,1 +1,3 @@
-<button class="btn btn-link" data-bind="click: sendTestMessage, enable: !busy(), css: {disabled: busy()}, visible: settings.settings.plugins.OctoText.show_navbar_button()"><i class="icon-spinner icon-spin" data-bind="visible: busy"></i> <i class="icon-envelope icon-white"></i></button>
+<button class="btn btn-link" data-bind="click: sendTestMessage, enable: !busy(), css: {disabled: busy()}, visible: settings.settings.plugins.OctoText.show_navbar_button()">
+    <i class="icon-spinner icon-spin" data-bind="visible: busy"></i>
+    <a href="#"></a><i class="icon-envelope icon-white" tool-tip-toggle="tooltip" title="OctoText Test"></i></button>

--- a/octoprint_OctoText/templates/OctoText_settings.jinja2
+++ b/octoprint_OctoText/templates/OctoText_settings.jinja2
@@ -153,7 +153,7 @@
             <div class="controls">
                 <input class="input-large" type="password" data-bind="value: settings.settings.plugins.OctoText.server_pass" required>
                 <span class="help-block">{% trans %}
-                        This is the password for your email account.
+                        This is the password for your email account.  Leave blank to disable SMTP authentication.
                     {% endtrans %}
                 </span>
             </div>

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ plugin_package = "octoprint_OctoText"
 plugin_name = "OctoPrint-OctoText"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.3.0rc1"
+plugin_version = "0.3.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
This addresses issue #91 

The change is pretty minor, I'm just skipping SMTP authentication in `smtp_login_server()` if the password field is left blank.

Thanks!
Andy