### PR TITLE
skip smtp auth if the password field is blank

### DIFF
--- a/octoprint_OctoText/__init__.py
+++ b/octoprint_OctoText/__init__.py
@@ -269,16 +269,20 @@ class OctoTextPlugin(
 
         # login to the mail account
         self._logger.debug(login)
-        try:
-            SMTP_server.login(login, passw)
-        except Exception as e:
-            self._logger.exception(
-                "Exception while logging into mail server {message}".format(
-                    message=str(e)
+        if passw:  # Only use SMTP auth if the password has been supplied, skip if blank - issue #91
+            self._logger.debug('Password supplied, attempting to log into mail server')
+            try:
+                SMTP_server.login(login, passw)
+            except Exception as e:
+                self._logger.exception(
+                    "Exception while logging into mail server {message}".format(
+                        message=str(e)
+                    )
                 )
-            )
-            SMTP_server.quit()
-            return ["LOGIN_E", None]
+                SMTP_server.quit()
+                return ["LOGIN_E", None]
+        else:
+            self._logger.debug('Password not supplied, proceeding without SMTP authentication.')
 
         email_addr = phone_numb + "@%s" % carrier_addr
         return [None, email_addr]

--- a/octoprint_OctoText/templates/OctoText_settings.jinja2
+++ b/octoprint_OctoText/templates/OctoText_settings.jinja2
@@ -177,7 +177,7 @@
             <div class="controls">
                 <input class="input-large" type="password" data-bind="value: settings.settings.plugins.OctoText.server_pass" required>
                 <span class="help-block">{% trans %}
-                        This is the password for your email account.
+                        This is the password for your email account.  Leave blank to disable SMTP authentication.
                     {% endtrans %}
                 </span>
             </div>


### PR DESCRIPTION
This addresses issue #91 

The change is pretty minor, I'm just skipping SMTP authentication in `smtp_login_server()` if the password field is left blank.

Thanks!
Andy