### PR TITLE
Added send_email-Helper

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [**.py]
-indent_style = tab
+indent_style = space
 
 [**.js]
 indent_style = space


### PR DESCRIPTION
See also discussion in issue  #112

With the new helper function ```send_email``` it is now possible to send an ```EMailMessage```-Object thru the OctoText-Plugin. OctoText handles the smtp connection, error handling and retry mechanism.

It could be used like this:
```python
    emailMessage = EmailMessage()
    emailMessage["Subject"] = "my Subject"
    emailMessage["From"] = "Backup@outlook.com"  # 'OctoText@outlook.com'
    emailMessage["To"] = "ollisgit+octobackup@gmail.com"
    emailMessage["Date"] = formatdate(localtime=True)
    emailMessage.set_content("This is my body message", charset="utf-8")

    helpers = self._plugin_manager.get_helpers("OctoText")
    sendEMailHelper = helpers["send_email"]
    sendEMailHelper(command="OctoText", data=emailMessage)

```

To realise this feature I "rearranged" the current implementation, so that the preparation of the email content (title, body, image, ...) is separated from the email sending part.

One method that receive the email data, create the email object and put it into the queue (or for connection-testing: send direct):
```python
def _prepare_email_message_and_send(self, title, body, sender=None, thumbnail=None, send_image=True, direct_send=False)
```
Each event-function now call this, instead of directly inserting partial data into the queue.







 